### PR TITLE
Update angular-load.js

### DIFF
--- a/angular-load.js
+++ b/angular-load.js
@@ -10,7 +10,7 @@
 
 			function loader(createElement) {
 				return function(url) {
-					if (typeof promises[url] === 'undefined') {
+					if (typeof promises[url] === 'undefined' || promises[url].$$state.status === 2) {
 						var deferred = $q.defer();
 						var element = createElement(url);
 


### PR DESCRIPTION
Hi Uri,

I'm using this lib and found a bug, when I try to load a CDN js file and the internet isn't available, the loader fall "deferred.reject(e);" in the line 28, however if I try to load the same CDN later, never enter in the statement "if (typeof promises[url] === 'undefined')" line 13, so I'm proposing a fix in the line 13, just putting the statement inside the if (typeof promises[url] === 'undefined' || promises[url].$$state.status === 2).

Regards,
Marcel