### PR TITLE
fix angular version cap in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   "homepage": "http://github.com/urish/angular-load",
   "main": "./dist/angular-load.js",
   "dependencies": {
-    "angular": ">=1.0.0 <1.6.0"
+    "angular": ">=1.0.0 <1.7.0"
   },
   "devDependencies": {
     "angular-mocks": "1.4.x"


### PR DESCRIPTION
`package.json` allows to use this package for versions of angular lower than 1.7.0.

This was not allowed in `bower.json`: https://github.com/urish/angular-load/commit/693d704c801d95190aaac06ecaafe1ce1c7d825b#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R10

This PR bumps cap for angular version in `bower.json`

Solves: https://github.com/urish/angular-load/issues/43